### PR TITLE
style: 통계 페이지 모바일 UI 수정

### DIFF
--- a/src/components/charts/CategoryComparisonModal.vue
+++ b/src/components/charts/CategoryComparisonModal.vue
@@ -36,11 +36,27 @@
           :key="row.category"
           class="comparison-row"
         >
-          <span class="fw-semibold kb-text-charcoal">{{ row.category }}</span>
-          <span class="text-secondary">{{ formatCurrency(row.previous) }}</span>
-          <span class="text-secondary">{{ formatCurrency(row.current) }}</span>
+          <span class="comparison-cell cell-category fw-semibold kb-text-charcoal">
+            {{ row.category }}
+          </span>
           <span
-            :class="row.diff >= 0 ? 'text-danger fw-bold' : 'text-primary fw-bold'"
+            class="comparison-cell cell-previous text-secondary"
+            :data-label="`${previousMonthLabel}월`"
+          >
+            {{ formatCurrency(row.previous) }}
+          </span>
+          <span
+            class="comparison-cell cell-current text-secondary"
+            :data-label="`${currentMonthLabel}월`"
+          >
+            {{ formatCurrency(row.current) }}
+          </span>
+          <span
+            :class="[
+              'comparison-cell cell-diff',
+              row.diff >= 0 ? 'text-danger fw-bold' : 'text-primary fw-bold',
+            ]"
+            data-label="변화"
           >
             {{ row.diff >= 0 ? '+' : '' }}{{ formatCurrency(row.diff) }}
           </span>
@@ -164,6 +180,13 @@ const closeModal = () => {
 }
 
 @media (max-width: 575.98px) {
+  .comparison-modal {
+    width: min(90vw, 560px);
+    max-height: 80vh;
+    overflow-y: auto;
+    padding: 1rem;
+  }
+
   .comparison-head,
   .comparison-row {
     grid-template-columns: 1fr;
@@ -180,6 +203,31 @@ const closeModal = () => {
     padding: 0.65rem;
     margin-bottom: 0.5rem;
     background: #fff;
+  }
+
+  .comparison-cell {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.6rem;
+    font-size: 0.88rem;
+  }
+
+  .cell-category {
+    display: block;
+    font-size: 0.92rem;
+    margin-bottom: 0.2rem;
+    padding-bottom: 0.35rem;
+    border-bottom: 1px dashed rgba(34, 34, 34, 0.12);
+  }
+
+  .cell-previous::before,
+  .cell-current::before,
+  .cell-diff::before {
+    content: attr(data-label);
+    font-size: 0.78rem;
+    color: #6b7280;
+    font-weight: 700;
   }
 }
 </style>

--- a/src/components/charts/MonthlyComparisonChart.vue
+++ b/src/components/charts/MonthlyComparisonChart.vue
@@ -12,9 +12,9 @@
     </div>
 
     <!-- trend(데이터) 없으면 렌더링 안되게 -->
-    <div v-if="trend.length" class="chart-wrap rounded-3">
+    <div v-if="visibleTrend.length" class="chart-wrap rounded-3">
       <div class="bars-wrap">
-        <div v-for="item in trend" :key="item.month" class="bar-item">
+        <div v-for="item in visibleTrend" :key="item.month" class="bar-item">
           <p class="bar-value mb-1">{{ formatCurrency(item.expense) }}</p>
           <div
             class="bar-fill"
@@ -38,7 +38,7 @@
 </template>
 
 <script setup>
-import { computed, onMounted, ref } from 'vue';
+import { computed, onBeforeUnmount, onMounted, ref } from 'vue';
 import { useFinanceStore } from '@/stores/finance';
 import { useStatisticsStore } from '@/stores/statistics';
 import CategoryComparisonModal from '@/components/charts/CategoryComparisonModal.vue';
@@ -53,13 +53,28 @@ const { getMonthKeys, ensureStatisticsData, getMonthlyComparisonChartData } =
 const currentMonth = computed(() => getMonthKeys().currentMonthKey);
 // 자세히 보기 모달 열림/닫힘 상태
 const isDetailModalOpen = ref(false);
+// 모바일 뷰포트 여부
+const isMobile = ref(false);
 
 // 최근 6개월 지출 추이/최대값 조회(막대 그래프 데이터)
 const chartData = computed(() =>
   getMonthlyComparisonChartData(currentMonth.value, 6),
 );
 const trend = computed(() => chartData.value.trend || []);
-const maxExpense = computed(() => Number(chartData.value.maxExpense || 1));
+// 모바일에서는 최근 3개만 표시
+const visibleTrend = computed(() =>
+  isMobile.value ? trend.value.slice(-3) : trend.value,
+);
+const maxExpense = computed(() => {
+  if (!visibleTrend.value.length) {
+    return 1;
+  }
+
+  return Math.max(
+    ...visibleTrend.value.map((item) => Number(item.expense || 0)),
+    1,
+  );
+});
 
 // 지출 금액을 퍼센트 높이로 변환
 const toHeightPercent = (expense) => {
@@ -68,9 +83,24 @@ const toHeightPercent = (expense) => {
   return Math.max(8, Math.round((value / max) * 100));
 };
 
+let mobileMediaQuery = null;
+const handleMobileChange = (event) => {
+  isMobile.value = event.matches;
+};
+
 onMounted(async () => {
   // 컴포넌트 마운트 시 거래 데이터 최신화
   await ensureStatisticsData();
+
+  mobileMediaQuery = window.matchMedia('(max-width: 575.98px)');
+  isMobile.value = mobileMediaQuery.matches;
+  mobileMediaQuery.addEventListener('change', handleMobileChange);
+});
+
+onBeforeUnmount(() => {
+  if (mobileMediaQuery) {
+    mobileMediaQuery.removeEventListener('change', handleMobileChange);
+  }
 });
 </script>
 
@@ -143,8 +173,7 @@ onMounted(async () => {
 
   .bars-wrap {
     grid-template-columns: repeat(3, minmax(0, 1fr));
-    row-gap: 1rem;
-    min-height: 24rem;
+    min-height: 14rem;
   }
 
   .bar-fill {


### PR DESCRIPTION
## #️⃣연관된 이슈

> #4

## 📝작업 내용

> 통계 페이지에서 모바일 환경일 때는 지난달 지출액 막대 그래프 3개만 렌더링

> 통계 페이지에서 모바일 환경일 때 자세히 보기 버튼을 누르면 나오는 모달 크기 
축소 및 스크롤 추가 및 지난달/이번달/변화 라벨 추가

## PR 유형
어떤 변경 사항이 있나요?

- [x] CSS 등 사용자 UI 디자인 변경


### 스크린샷

<img width="278" height="625" alt="1" src="https://github.com/user-attachments/assets/448dbe31-ad41-4e44-bb62-8a4505d80682" />

<img width="724" height="696" alt="2" src="https://github.com/user-attachments/assets/e145d6ec-63b8-4d5c-ae0e-80a8fc00e71c" />


## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.) 
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
